### PR TITLE
Added more robust error handling for loadJS

### DIFF
--- a/src/simulator/interface/framework.js
+++ b/src/simulator/interface/framework.js
@@ -158,11 +158,12 @@ var framework = {
         document.body.appendChild(css);
 	},
 
-	loadJS: function(filename, callback) {
+	loadJS: function(filename, callback, errCallback) {
 		var script = document.createElement('script');
         script.type = 'text/javascript';
         script.src = filename;
         script.onload = callback;
+        script.onerror = errCallback || function(errObj) { Logger.error("Unable to load script source at " + filename); };
         document.body.appendChild(script);
 	},
 


### PR DESCRIPTION
If the user chooses an incorrect location for runtime SDK, the app will simply hang. For better error handling, we can detect the error and alert the user.
