### PR TITLE
[sdk-simulator] Update README with instructions on how to setup sdk f…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,24 @@
 
 This is under heavy development currently.
 
+## Getting Started
+Clone the SDK repository:  
+`git clone https://github.com/flyandi/mazda-custom-application-sdk`
+
+Then, build the SDK from the SDK directory:  
+```
+npm install
+npm run build-install
+```
+
+To run the simulator, clone this repository after setting up the SDK and run:  
+```
+npm install
+npm run simulator
+```
+
+Set the runtime SDK location to `<SDK_base_directory>/build/system`.
+
 ## Discussion
 
 The official discussion thread is on Mazda3Revolution:


### PR DESCRIPTION
…or launching simulator

It's unclear how to set up the simulator for someone new to developing. Added basic quick setup instructions for the SDK to run the simulator.
